### PR TITLE
VIVI-22 delete issue on todoist delete

### DIFF
--- a/src/clients/linearClient.ts
+++ b/src/clients/linearClient.ts
@@ -74,6 +74,25 @@ export async function addCommentToIssue(
   return success;
 }
 
+export async function deleteIssue(issueId: IssueInfo["id"]) {
+  const body = JSON.stringify({
+    query: `
+      mutation IssueDelete($id: String!) {
+        issueDelete(id: $id) {
+          success
+        }
+      }
+    `,
+    variables: {
+      id: issueId,
+    },
+  });
+
+  const response: any = await client(body);
+  const success = response?.data?.issueDelete?.success;
+  return success;
+}
+
 export async function returnIssueInfo(request: Request) {
   const body: any = await request.json();
   const info: IssueInfo = {

--- a/src/processTodoistTask.ts
+++ b/src/processTodoistTask.ts
@@ -1,5 +1,5 @@
 import { getTaskFromDb } from "./clients/dbClient";
-import { addCommentToIssue, markIssueComplete } from "./clients/linearClient";
+import { deleteIssue, markIssueComplete } from "./clients/linearClient";
 import { returnTaskInfo, TaskInfo } from "./clients/todoistClient";
 import { Task, Team } from "./types/database";
 
@@ -40,10 +40,10 @@ export async function processTodoistTask(issue: Request, db: any) {
           throw new Error(error);
         }
 
-        await addCommentToIssue(
-          task.linear_task_id,
-          "Issue deleted from Todoist. Updates will no longer be synced."
-        );
+        await deleteIssue(task.linear_task_id).catch((err) => {
+          console.error(`Unable to delete issue in Linear: ${err}`);
+          throw err;
+        });
 
         return {
           task: data["0"],


### PR DESCRIPTION
## Summary
- remove comment-only behavior when Todoist task gets deleted
- delete the corresponding Linear issue instead

## Testing
- `npm test` *(fails: Missing script)*
- `npx tsc -p tsconfig.json` *(fails: cannot find type definitions)*

------
https://chatgpt.com/codex/tasks/task_e_6844e3f2cb6c832bbe3902d5860693f6