### PR TITLE
Move Todoist task when Linear issue moves between teams

### DIFF
--- a/src/clients/linearClient.ts
+++ b/src/clients/linearClient.ts
@@ -108,6 +108,8 @@ export async function returnIssueInfo(request: Request) {
     assigneeId: body.data.assigneeId,
     dueDate: body.data.dueDate,
     url: body.data.url,
+    teamId: body.data.teamId,
+    previousTeamId: body.updatedFrom?.teamId,
     state: {
       name: body.data.state.name,
       type: body.data.state.type,
@@ -125,6 +127,8 @@ export interface IssueInfo {
   assigneeId?: string;
   dueDate: DateYMDString | null;
   url: string;
+  teamId?: string;
+  previousTeamId?: string;
   state: IssueInfoState;
 }
 

--- a/src/clients/todoistClient.ts
+++ b/src/clients/todoistClient.ts
@@ -97,6 +97,20 @@ export async function updateTask(
   return response.json();
 }
 
+export async function moveTask(
+  taskId: Task["todoist_task_id"],
+  projectId: string
+) {
+  const response = await fetch(`${urlBase}/tasks/${taskId}/move`, {
+    headers,
+    method: "POST",
+    body: JSON.stringify({ project_id: projectId }),
+  });
+
+  await assertOk(response, "Todoist moveTask");
+  return response.json();
+}
+
 export async function deleteTask(taskId: Task["todoist_task_id"]) {
   const response = await fetch(`${urlBase}/tasks/${taskId}`, {
     headers,

--- a/src/processLinearTask.ts
+++ b/src/processLinearTask.ts
@@ -95,10 +95,6 @@ export async function processLinearTask(issue: Request, db: any) {
 
           if (destTeam?.todoist_project_id) {
             await moveTask(task.todoist_task_id, destTeam.todoist_project_id);
-            await addCommentToIssue(
-              info.id,
-              `Issue moved to ${destTeam.name}. Todoist task relocated.`
-            );
             return {
               success: true,
               message: `Task moved to project ${destTeam.todoist_project_id}`,

--- a/src/processLinearTask.ts
+++ b/src/processLinearTask.ts
@@ -10,7 +10,7 @@ import {
   moveTask,
   updateTask,
 } from "./clients/todoistClient";
-import { Task, Team } from "./types/database";
+import { Task } from "./types/database";
 
 const activeStates = ["unstarted", "started"];
 const completeStates = ["completed"];
@@ -77,32 +77,6 @@ export async function processLinearTask(issue: Request, db: any) {
           .select()
           .eq("linear_task_id", info.id)
           .maybeSingle();
-
-        // Team move: relocate the Todoist task to the destination team's project.
-        // updatedFrom.teamId is only present when the team actually changed.
-        if (
-          info.previousTeamId &&
-          info.teamId &&
-          info.previousTeamId !== info.teamId &&
-          task &&
-          task.active
-        ) {
-          const { data: destTeam }: { data: Team | null } = await db
-            .from("team")
-            .select()
-            .eq("linear_team_id", info.teamId)
-            .maybeSingle();
-
-          if (destTeam?.todoist_project_id) {
-            await moveTask(task.todoist_task_id, destTeam.todoist_project_id);
-            return {
-              success: true,
-              message: `Task moved to project ${destTeam.todoist_project_id}`,
-            };
-          }
-          // No destination team configured — fall through to state-based logic,
-          // which will delete the task if the new team places it in a backlog state.
-        }
 
         // If task completed in Linear
         if (completeStates.includes(info.state.type)) {
@@ -204,7 +178,17 @@ export async function processLinearTask(issue: Request, db: any) {
 
             return data[0];
           } else {
-            // Task exists and is active - update it
+            // Task exists and is active - move it if team changed, then update fields
+            if (info.previousTeamId) {
+              const { data: destTeam } = await db
+                .from("team")
+                .select()
+                .eq("linear_team_id", info.teamId)
+                .maybeSingle();
+              if (destTeam?.todoist_project_id) {
+                await moveTask(task.todoist_task_id, destTeam.todoist_project_id);
+              }
+            }
             const updated = await updateTask(task.todoist_task_id, {
               content: info.title,
               due_date: info.dueDate || null,

--- a/src/processLinearTask.ts
+++ b/src/processLinearTask.ts
@@ -3,8 +3,14 @@ import {
   IssueInfo,
   returnIssueInfo,
 } from "./clients/linearClient";
-import { addTask, completeTask, deleteTask, updateTask } from "./clients/todoistClient";
-import { Task } from "./types/database";
+import {
+  addTask,
+  completeTask,
+  deleteTask,
+  moveTask,
+  updateTask,
+} from "./clients/todoistClient";
+import { Task, Team } from "./types/database";
 
 const activeStates = ["unstarted", "started"];
 const completeStates = ["completed"];
@@ -71,6 +77,36 @@ export async function processLinearTask(issue: Request, db: any) {
           .select()
           .eq("linear_task_id", info.id)
           .maybeSingle();
+
+        // Team move: relocate the Todoist task to the destination team's project.
+        // updatedFrom.teamId is only present when the team actually changed.
+        if (
+          info.previousTeamId &&
+          info.teamId &&
+          info.previousTeamId !== info.teamId &&
+          task &&
+          task.active
+        ) {
+          const { data: destTeam }: { data: Team | null } = await db
+            .from("team")
+            .select()
+            .eq("linear_team_id", info.teamId)
+            .maybeSingle();
+
+          if (destTeam?.todoist_project_id) {
+            await moveTask(task.todoist_task_id, destTeam.todoist_project_id);
+            await addCommentToIssue(
+              info.id,
+              `Issue moved to ${destTeam.name}. Todoist task relocated.`
+            );
+            return {
+              success: true,
+              message: `Task moved to project ${destTeam.todoist_project_id}`,
+            };
+          }
+          // No destination team configured — fall through to state-based logic,
+          // which will delete the task if the new team places it in a backlog state.
+        }
 
         // If task completed in Linear
         if (completeStates.includes(info.state.type)) {


### PR DESCRIPTION
When a Linear issue's team changes, relocate the linked Todoist task to the destination team's configured project instead of leaving it orphaned in the original project.

- Surface teamId and previousTeamId on IssueInfo from the webhook payload
- Add moveTask() in todoistClient using the /tasks/:id/move endpoint
- In processLinearTask, detect team changes and move the active task to the destination team's todoist_project_id, with a comment back on the Linear issue. Falls through to state-based logic if the destination team has no Todoist project configured.