### PR TITLE
Fix Todoist cancel sync: match Linear "canceled" spelling + mark tasks active on creation

### DIFF
--- a/src/processLinearTask.ts
+++ b/src/processLinearTask.ts
@@ -14,7 +14,9 @@ import { Task } from "./types/database";
 
 const activeStates = ["unstarted", "started"];
 const completeStates = ["completed"];
-const backlogStates = ["backlog", "triage", "cancelled"];
+// NOTE: Linear's state.type for cancelled issues is "canceled" (one L, American
+// spelling). A previous "cancelled" here never matched, so cancel never deleted.
+const backlogStates = ["backlog", "triage", "canceled"];
 
 /**
  * Helper function to create a new Todoist task and database entry for a Linear issue
@@ -31,7 +33,7 @@ async function createTaskInTodoistAndDb(
   });
   const { data, error } = await db
     .from("task")
-    .insert({ todoist_task_id: task.id, linear_task_id: info.id });
+    .insert({ todoist_task_id: task.id, linear_task_id: info.id, active: true });
 
   if (error) {
     console.error("error adding task to database", error);


### PR DESCRIPTION
Fixes the cancel/backlog → Todoist deletion that never worked.

## Root causes
1. **Spelling mismatch (the cancel bug):** `backlogStates` had `"cancelled"` (two L's) but Linear sends `state.type = "canceled"` (one L) — so canceled issues matched no branch and nothing happened. Introduced in `ea402a2`.
2. **`active` never set on creation:** tasks were inserted without `active: true`, so the `if (task && task.active)` delete guard was false (blocked backlog deletes + caused duplicate tasks on first edit).

## Changes (`src/processLinearTask.ts`)
- `backlogStates` → `["backlog", "triage", "canceled"]`
- Insert new tasks with `active: true`

Prod DB already backfilled: 25 live modern-ID tasks set `active=true`. 60 legacy numeric-ID tasks (old REST v2) need separate ID remapping.

Linear: VIVI-121

🤖 Generated with [Claude Code](https://claude.com/claude-code)